### PR TITLE
Follow-up to #110: decouple All-lines container key + Joint/Granular tests

### DIFF
--- a/specs/common.spec.ts
+++ b/specs/common.spec.ts
@@ -72,6 +72,7 @@ import { AreaComponent } from "../src/visualComponent/combo/areaComponent";
 import { ComboComponent } from "../src/visualComponent/combo/comboComponent";
 
 import {
+    LineColorMode,
     LineInterpolation,
     LineStyle,
     LineType,
@@ -1080,6 +1081,74 @@ describe("Power KPI", () => {
             expect(colors.length).toBeGreaterThan(1);
             colors.forEach(color => expect(color).toBeDefined());
             expect(new Set(colors).size).toBe(colors.length);
+        });
+
+        describe("line color mode (Joint/Granular)", () => {
+            const groupValues: string[] = ["GroupA", "GroupB"];
+            const measureNames: string[] = ["Sales", "Cost"];
+
+            function convertGrouped(mode: LineColorMode): IDataRepresentation {
+                const dataView: powerbi.DataView = new DataBuilder()
+                    .getGroupedDataView(groupValues, measureNames);
+
+                const settings: Settings = new Settings();
+                settings.line.mode.value = { value: mode } as any;
+
+                const dataConverter: DataConverter = new DataConverter({
+                    colorPalette: createColorPalette(),
+                    createSelectionIdBuilder,
+                });
+
+                dataConverter.getAxisType({
+                    dataView,
+                    xAxisType: AxisType.continuous,
+                });
+
+                return dataConverter.convert({
+                    dataView,
+                    hasSelection: false,
+                    settings,
+                    viewport: { width: 100, height: 100 },
+                    locale: "en-US"
+                });
+            }
+
+            it("Joint mode groups every measure of a group under a single container", () => {
+                const dataRepresentation: IDataRepresentation = convertGrouped(LineColorMode.joint);
+
+                expect(dataRepresentation.isGrouped).toBeTrue();
+                expect(dataRepresentation.series.length).toBe(groupValues.length * measureNames.length);
+
+                const containerNames: string[] = dataRepresentation.series.map(series => series.containerName);
+
+                // One container per group, shared by all measures of that group.
+                expect(new Set(containerNames).size).toBe(groupValues.length);
+                groupValues.forEach(group => expect(containerNames).toContain(group));
+            });
+
+            it("Granular mode gives every line its own container", () => {
+                const dataRepresentation: IDataRepresentation = convertGrouped(LineColorMode.granular);
+
+                expect(dataRepresentation.isGrouped).toBeTrue();
+                expect(dataRepresentation.series.length).toBe(groupValues.length * measureNames.length);
+
+                const containerNames: string[] = dataRepresentation.series.map(series => series.containerName);
+
+                // One container per line; container name equals the full series name.
+                expect(new Set(containerNames).size).toBe(dataRepresentation.series.length);
+                dataRepresentation.series.forEach(series =>
+                    expect(series.containerName).toBe(series.name));
+            });
+
+            it("keeps a distinct default color per line in both modes", () => {
+                [LineColorMode.joint, LineColorMode.granular].forEach(mode => {
+                    const dataRepresentation: IDataRepresentation = convertGrouped(mode);
+                    const colors: string[] = dataRepresentation.series.map(series => series.color);
+
+                    colors.forEach(color => expect(color).toBeDefined());
+                    expect(new Set(colors).size).toBe(colors.length);
+                });
+            });
         });
 
         describe("isValueFinite", () => {

--- a/specs/dataBuilder.ts
+++ b/specs/dataBuilder.ts
@@ -26,7 +26,7 @@
 
 import powerbi from "powerbi-visuals-api";
 
-import { getRandomNumbers, testDataViewBuilder } from "powerbi-visuals-utils-testutils";
+import { getRandomNumbers, testDataViewBuilder, createCategoricalDataViewBuilder } from "powerbi-visuals-utils-testutils";
 import { valueType } from "powerbi-visuals-utils-typeutils";
 
 import { getDateRange } from "./helpers";
@@ -85,5 +85,52 @@ export class DataBuilder extends testDataViewBuilder.TestDataViewBuilder {
             valuesCategory,
             columnNames,
         ).build();
+    }
+
+    /**
+     * Builds a grouped (dynamic series) data view: each group value (e.g. "GroupA")
+     * carries the same set of measures. Used to exercise the Joint/Granular line
+     * color modes, which depend on `columnGroup.identity` being present.
+     */
+    public getGroupedDataView(
+        groupValues: string[] = ["GroupA", "GroupB"],
+        measureNames: string[] = ["Sales", "Cost"],
+    ): powerbi.DataView {
+        return createCategoricalDataViewBuilder()
+            .withCategory({
+                source: {
+                    displayName: DataBuilder.CategoryColumnName,
+                    format: "%M/%d/yyyy",
+                    roles: { Axis: true },
+                    type: valueType.ValueType.fromDescriptor({ dateTime: true }),
+                },
+                values: this.dates,
+                identityFrom: { fields: [] },
+            })
+            .withGroupedValues({
+                groupColumn: {
+                    source: {
+                        displayName: "Series",
+                        roles: { SeriesColumn: true },
+                        type: valueType.ValueType.fromDescriptor({ text: true }),
+                    },
+                    values: groupValues,
+                    identityFrom: { fields: [{}] },
+                },
+                valueColumns: measureNames.map((name: string) => ({
+                    source: {
+                        displayName: name,
+                        queryName: `Sum(${name})`,
+                        roles: { Values: true },
+                        type: valueType.ValueType.fromDescriptor({ integer: true }),
+                    },
+                })),
+                data: groupValues.map(() =>
+                    measureNames.map(() => ({
+                        values: getRandomNumbers(this.dates.length, 0, 100),
+                    })),
+                ),
+            })
+            .build();
     }
 }

--- a/src/settings/descriptors/line/lineDescriptor.ts
+++ b/src/settings/descriptors/line/lineDescriptor.ts
@@ -284,8 +284,13 @@ export class LineDescriptor extends BaseDescriptor {
         this.interpolationWithColorizedLine
     ]
 
+    // `displayName` is a stable internal key used only for container lookup in
+    // `getCurrentSettings`; it is intentionally NOT localized to avoid colliding
+    // with a real series/group name. `displayNameKey` drives the localized label
+    // shown in the formatting pane.
     public allLinesContainerItem: ContainerItem = {
         displayName: "[ALL]",
+        displayNameKey: "Visual_Line_All_Default",
         slices: [...this.defaultSlices]
     };
 
@@ -402,7 +407,6 @@ export class LineDescriptor extends BaseDescriptor {
 
     public setLocalizedDisplayName(localizationManager: ILocalizationManager) {
         super.setLocalizedDisplayName(localizationManager);
-        this.allLinesContainerItem.displayName = localizationManager.getDisplayName("Visual_Line_All_Default");
         [lineStyleOptions, interpolationWithColorizedLineOptions, lineTypeOptions, interpolationOptions, lineColorModeOptions].forEach(list => 
             list.forEach(option => {
                 option.displayName = localizationManager.getDisplayName(option.displayNameKey)


### PR DESCRIPTION
## Summary

Follow-up to #110 addressing two review comments from that PR.

### 1. Decouple the All-lines container lookup key from its localized label
`getCurrentSettings` matches formatting containers by `displayName`. After #110 the All-lines item's `displayName` was localized to "All lines (default)", which (in theory) could collide with a real series/group named the same.

This keeps `displayName: "[ALL]"` as a **stable internal lookup key** and renders the localized label via `displayNameKey` (the formatting framework localizes `ContainerItem.displayNameKey` for display and uses it for the UID). Net result: the UI still shows "All lines (default)", but the lookup key is no longer a user-facing string. **No user-facing change.**

### 2. Unit tests for Joint/Granular line color modes
Adds a grouped (dynamic series) dataView builder (`DataBuilder.getGroupedDataView`) and specs that assert:
- **Joint** groups every measure of a group under a single container (one container per group).
- **Granular** gives every line its own container (container name == full series name).
- Each line keeps a distinct default color in both modes (guards the shared-color regression).

## Validation
- `npx tsc --noEmit` — clean
- `npm run lint` — clean
- `npm test` — 44/44 pass (3 new)

No version bump: changes are test-only plus an internal, non-user-facing refinement.
