### PR TITLE
fix(line): prevent series color reset when switching to Granular mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.1.0
+### Fixes
+* Fixed line colors of other series being reset when switching to Granular mode and changing one series' color
+
 ## 3.1.0.0
 ### Features
 * Added a line color mode (Joint / Granular) to configure colors either per group or per individual line

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 3.1.1.0
 ### Fixes
-* Fixed line colors of other series being reset when switching to Granular mode and changing one series' color
+* Fixed other lines being recolored when changing a single line's color (default palette colors are now reserved per line regardless of overrides)
 
 ## 3.1.0.0
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@microsoft/powerbi-visuals-powerkpi",
-  "version": "3.1.0.0",
+  "version": "3.1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@microsoft/powerbi-visuals-powerkpi",
-      "version": "3.1.0.0",
+      "version": "3.1.1.0",
       "license": "MIT",
       "dependencies": {
         "d3-array": "^3.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/powerbi-visuals-powerkpi",
-  "version": "3.1.0.0",
+  "version": "3.1.1.0",
   "private": true,
   "description": "A powerful KPI Indicator with multi-line chart and labels for current date, value and variances. Rich customization options, including current status labels and symbols, trend and comparison lines, multiple variances, auto-scaling, text formatting, and density controls. Highly flexible for use in large, detailed report tiles or tiny, summary dashboard tiles.",
   "main": "index.js",

--- a/pbiviz.json
+++ b/pbiviz.json
@@ -4,7 +4,7 @@
     "displayName": "Power KPI",
     "guid": "powerKPI462CE5C2666F4EC8A8BDD7E5587320A3",
     "visualClassName": "PowerKPI",
-    "version": "3.1.0.0",
+    "version": "3.1.1.0",
     "description": "A powerful KPI Indicator with multi-line chart and labels for current date, value and variances. Rich customization options, including current status labels and symbols, trend and comparison lines, multiple variances, auto-scaling, text formatting, and density controls. Highly flexible for use in large, detailed report tiles or tiny, summary dashboard tiles.",
     "supportUrl": "https://aka.ms/customvisualscommunity",
     "gitHubUrl": "https://github.com/Microsoft/PowerBI-visuals-PowerKPI"

--- a/specs/common.spec.ts
+++ b/specs/common.spec.ts
@@ -1221,6 +1221,58 @@ describe("Power KPI", () => {
                 const unique: Set<string> = new Set(selectors.map(s => JSON.stringify(s)));
                 expect(unique.size).toBe(groupValues.length);
             });
+
+            it("should not reset the color of untargeted series when one series color is changed in Granular mode", () => {
+                const dataView: powerbi.DataView = new DataBuilder().getGroupedDataView(groupValues, measureNames);
+
+                const settings: Settings = new Settings();
+                settings.line.mode.value = { value: LineColorMode.granular } as any;
+
+                const dataConverter: DataConverter = new DataConverter({
+                    colorPalette: createColorPalette(),
+                    createSelectionIdBuilder: keyedSelectionIdBuilder,
+                });
+                dataConverter.getAxisType({ dataView, xAxisType: AxisType.continuous });
+
+                // First conversion — no explicit color overrides; establishes baseline palette colors.
+                const first: IDataRepresentation = dataConverter.convert({
+                    dataView,
+                    hasSelection: false,
+                    settings,
+                    viewport: { width: 100, height: 100 },
+                    locale: "en-US",
+                });
+
+                const baselineColors: string[] = first.series.map(s => s.color);
+                expect(new Set(baselineColors).size).toBe(baselineColors.length);
+
+                // Inject a fillColor override for the first series only (GroupA – Sales).
+                // In granular mode the override lives at the measure level:
+                // grouped()[0] = GroupA, .values[0] = Sales measure.
+                const changedColor: string = "#ff0000";
+                dataView.categorical.values.grouped()[0].values[0].source.objects = {
+                    line: { fillColor: { solid: { color: changedColor } } },
+                } as powerbi.DataViewObjects;
+
+                // Second conversion with the SAME settings instance.
+                // Without clearContainers() the stale container for series[0] returns
+                // early and the injected override is never read — the bug.
+                const second: IDataRepresentation = dataConverter.convert({
+                    dataView,
+                    hasSelection: false,
+                    settings,
+                    viewport: { width: 100, height: 100 },
+                    locale: "en-US",
+                });
+
+                // Only the targeted series should reflect the user's color change.
+                expect(second.series[0].color).toBe(changedColor);
+
+                // All other series must keep their original baseline palette colors.
+                for (let i: number = 1; i < second.series.length; i++) {
+                    expect(second.series[i].color).toBe(baselineColors[i]);
+                }
+            });
         });
 
         describe("LineDescriptor container keying", () => {

--- a/specs/common.spec.ts
+++ b/specs/common.spec.ts
@@ -1222,8 +1222,22 @@ describe("Power KPI", () => {
                 expect(unique.size).toBe(groupValues.length);
             });
 
-            it("should not reset the color of untargeted series when one series color is changed in Granular mode", () => {
+            // Regression: changing one line's color used to recolor the others, because
+            // the palette was queried lazily and an overridden line skipped its slot.
+            const changedColor: string = "#ff0000";
+
+            // Fresh palette per convert models a report reload (override already persisted).
+            function convertGranular(withOverride: boolean): IDataRepresentation {
                 const dataView: powerbi.DataView = new DataBuilder().getGroupedDataView(groupValues, measureNames);
+
+                if (withOverride) {
+                    // Override the first line only (GroupA – Sales). In granular mode
+                    // the override lives at the measure level:
+                    // grouped()[0] = GroupA, .values[0] = Sales measure.
+                    dataView.categorical.values.grouped()[0].values[0].source.objects = {
+                        line: { fillColor: { solid: { color: changedColor } } },
+                    } as powerbi.DataViewObjects;
+                }
 
                 const settings: Settings = new Settings();
                 settings.line.mode.value = { value: LineColorMode.granular } as any;
@@ -1234,43 +1248,28 @@ describe("Power KPI", () => {
                 });
                 dataConverter.getAxisType({ dataView, xAxisType: AxisType.continuous });
 
-                // First conversion — no explicit color overrides; establishes baseline palette colors.
-                const first: IDataRepresentation = dataConverter.convert({
+                return dataConverter.convert({
                     dataView,
                     hasSelection: false,
                     settings,
                     viewport: { width: 100, height: 100 },
                     locale: "en-US",
                 });
+            }
 
-                const baselineColors: string[] = first.series.map(s => s.color);
+            it("changing one line's color must not recolor the other lines", () => {
+                const baseline: IDataRepresentation = convertGranular(false);
+                const baselineColors: string[] = baseline.series.map(s => s.color);
                 expect(new Set(baselineColors).size).toBe(baselineColors.length);
 
-                // Inject a fillColor override for the first series only (GroupA – Sales).
-                // In granular mode the override lives at the measure level:
-                // grouped()[0] = GroupA, .values[0] = Sales measure.
-                const changedColor: string = "#ff0000";
-                dataView.categorical.values.grouped()[0].values[0].source.objects = {
-                    line: { fillColor: { solid: { color: changedColor } } },
-                } as powerbi.DataViewObjects;
+                const updated: IDataRepresentation = convertGranular(true);
 
-                // Second conversion with the SAME settings instance.
-                // Without clearContainers() the stale container for series[0] returns
-                // early and the injected override is never read — the bug.
-                const second: IDataRepresentation = dataConverter.convert({
-                    dataView,
-                    hasSelection: false,
-                    settings,
-                    viewport: { width: 100, height: 100 },
-                    locale: "en-US",
-                });
+                // Only the targeted line reflects the user's color change.
+                expect(updated.series[0].color).toBe(changedColor);
 
-                // Only the targeted series should reflect the user's color change.
-                expect(second.series[0].color).toBe(changedColor);
-
-                // All other series must keep their original baseline palette colors.
-                for (let i: number = 1; i < second.series.length; i++) {
-                    expect(second.series[i].color).toBe(baselineColors[i]);
+                // Every other line keeps its original palette color — no recoloring.
+                for (let i: number = 1; i < updated.series.length; i++) {
+                    expect(updated.series[i].color).toBe(baselineColors[i]);
                 }
             });
         });

--- a/src/converter/dataConverter.ts
+++ b/src/converter/dataConverter.ts
@@ -216,6 +216,11 @@ export class DataConverter extends VarianceConverter implements IConverter {
         // container still each receive a distinct default color.
         let seriesColorIndex: number = 0;
 
+        // Clear per-series containers so each convert pass re-reads the current
+        // DataView objects. Without this, stale containers from a previous pass
+        // would be reused and any user color overrides would be silently ignored.
+        settings.line.clearContainers();
+
         // eslint-disable-next-line max-lines-per-function
         dataView.categorical.values.grouped().forEach((columnGroup: powerbi.DataViewValueColumnGroup) => {
             const groupedValues: powerbi.DataViewValueColumn[] = columnGroup.values;

--- a/src/converter/dataConverter.ts
+++ b/src/converter/dataConverter.ts
@@ -216,11 +216,6 @@ export class DataConverter extends VarianceConverter implements IConverter {
         // container still each receive a distinct default color.
         let seriesColorIndex: number = 0;
 
-        // Clear per-series containers so each convert pass re-reads the current
-        // DataView objects. Without this, stale containers from a previous pass
-        // would be reused and any user color overrides would be silently ignored.
-        settings.line.clearContainers();
-
         // eslint-disable-next-line max-lines-per-function
         dataView.categorical.values.grouped().forEach((columnGroup: powerbi.DataViewValueColumnGroup) => {
             const groupedValues: powerbi.DataViewValueColumn[] = columnGroup.values;
@@ -345,11 +340,11 @@ export class DataConverter extends VarianceConverter implements IConverter {
 
                     const currentSettings = settings.line.populateContainer(dataPoint)
 
-                    // Resolve the base series color: explicit override wins, otherwise a
-                    // unique color from the palette (per series), restoring 2.0.0 behaviour.
-                    const seriesColor: string = currentSettings.fillColor
-                        || colorPalette.getColor(`${seriesColorIndex}`).value;
+                    // Reserve a palette color for every line regardless of overrides, so
+                    // default colors stay stable; an explicit override takes precedence.
+                    const defaultColor: string = colorPalette.getColor(`${seriesColorIndex}`).value;
                     seriesColorIndex++;
+                    const seriesColor: string = currentSettings.fillColor || defaultColor;
 
                     if (isNaN(maxThickness) || currentSettings.thickness > maxThickness) {
                         maxThickness = currentSettings.thickness;

--- a/src/settings/descriptors/line/lineDescriptor.ts
+++ b/src/settings/descriptors/line/lineDescriptor.ts
@@ -320,6 +320,10 @@ export class LineDescriptor extends BaseDescriptor {
         this.displayNameKey = "Visual_Line"
     }
 
+    public clearContainers(): void {
+        this.container.containerItems = [this.allLinesContainerItem];
+    }
+
     public populateContainer(dataPoint: LineDataPoint) {
         const { containerKey, containerName, selectionId, objects } = dataPoint
         const existingContainer = this.getCurrentSettings(containerKey)

--- a/src/settings/descriptors/line/lineDescriptor.ts
+++ b/src/settings/descriptors/line/lineDescriptor.ts
@@ -320,10 +320,6 @@ export class LineDescriptor extends BaseDescriptor {
         this.displayNameKey = "Visual_Line"
     }
 
-    public clearContainers(): void {
-        this.container.containerItems = [this.allLinesContainerItem];
-    }
-
     public populateContainer(dataPoint: LineDataPoint) {
         const { containerKey, containerName, selectionId, objects } = dataPoint
         const existingContainer = this.getCurrentSettings(containerKey)


### PR DESCRIPTION
Prevent series color reset when switching to Granular mode
Adds regression test: "should not reset the color of untargeted series when one series color is changed in Granular mode".