### PR TITLE
fix(axes): thin out overlapping X-axis tick labels instead of truncating all of them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Added a line color mode (Joint / Granular) to configure colors either per group or per individual line
 ### Fixes
 * Fixed series colors being shared between measures of the same group
+* Fixed X-axis tick labels overlapping when the visual is narrowed and the axis font size is increased - the axis now redistributes to fewer, wider-spaced ticks that fit their available space, falling back to per-label truncation only when a single tick still can't fit
 
 ## 3.0.4.0
 ### Fixes

--- a/specs/xAxisTickLabelOverlap.spec.ts
+++ b/specs/xAxisTickLabelOverlap.spec.ts
@@ -1,0 +1,331 @@
+/*
+ *  Power BI Visualizations
+ *
+ *  Copyright (c) Microsoft Corporation
+ *  All rights reserved.
+ *  MIT License
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the ""Software""), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+
+import powerbi from "powerbi-visuals-api";
+import { select as d3Select } from "d3-selection";
+import { Selection } from "d3-selection";
+
+import { testDom, createColorPalette } from "powerbi-visuals-utils-testutils";
+import { valueType } from "powerbi-visuals-utils-typeutils";
+import { IMargin } from "powerbi-visuals-utils-svgutils";
+
+import { XAxisComponent, IXAxisComponentRenderOptions } from "../src/visualComponent/axes/xAxisComponent";
+import { IDataRepresentationX } from "../src/dataRepresentation/dataRepresentationAxis";
+import { DataRepresentationScale } from "../src/dataRepresentation/dataRepresentationScale";
+import { DataRepresentationTypeEnum } from "../src/dataRepresentation/dataRepresentationType";
+import { Settings } from "../src/settings/settings";
+import { getDateRange } from "./helpers";
+
+/**
+ * Builds an X axis representation for a date range spanning several months, matching the kind
+ * of dataset that renders "MMM yyyy" tick labels (e.g. "Jan 2017", "Feb 2017", ... "Jun 2017").
+ */
+function buildDateAxis(minDate: Date, maxDate: Date): IDataRepresentationX {
+    const scale: DataRepresentationScale = DataRepresentationScale
+        .create()
+        .domain([minDate, maxDate], DataRepresentationTypeEnum.DateType);
+
+    return {
+        axisType: DataRepresentationTypeEnum.DateType,
+        format: null,
+        max: maxDate,
+        metadata: {
+            displayName: "Axis",
+            type: valueType.ValueType.fromDescriptor({ dateTime: true }),
+        } as powerbi.DataViewMetadataColumn,
+        min: minDate,
+        name: "Axis",
+        scale,
+        values: getDateRange(minDate, maxDate, 24 * 3600 * 1000),
+    };
+}
+
+/**
+ * Builds a purely numeric X axis (e.g. a scatter/line chart plotted against a numeric measure
+ * rather than a date or category). Unlike date axes, the numeric branch of createScale() in
+ * axisHelper.ts has no floor on the computed tick count - it can legitimately be driven to 0.
+ */
+function buildNumberAxis(min: number, max: number): IDataRepresentationX {
+    const scale: DataRepresentationScale = DataRepresentationScale
+        .create()
+        .domain([min, max], DataRepresentationTypeEnum.NumberType);
+
+    return {
+        axisType: DataRepresentationTypeEnum.NumberType,
+        format: null,
+        max,
+        metadata: {
+            displayName: "Axis",
+            type: valueType.ValueType.fromDescriptor({ numeric: true }),
+        } as powerbi.DataViewMetadataColumn,
+        min,
+        name: "Axis",
+        scale,
+        values: [min, max],
+    };
+}
+
+/**
+ * Builds a categorical (string) X axis - e.g. a bar/line chart plotted against a text category.
+ */
+function buildStringAxis(categories: string[]): IDataRepresentationX {
+    const scale: DataRepresentationScale = DataRepresentationScale
+        .create()
+        .domain(categories, DataRepresentationTypeEnum.StringType);
+
+    return {
+        axisType: DataRepresentationTypeEnum.StringType,
+        format: null,
+        max: categories[categories.length - 1],
+        metadata: {
+            displayName: "Axis",
+            type: valueType.ValueType.fromDescriptor({ text: true }),
+        } as powerbi.DataViewMetadataColumn,
+        min: categories[0],
+        name: "Axis",
+        scale,
+        values: categories,
+    };
+}
+
+function createRenderOptions(
+    viewport: powerbi.IViewport,
+    fontSize: number,
+    density: number,
+    axis: IDataRepresentationX,
+): IXAxisComponentRenderOptions {
+    const settings: Settings = new Settings();
+
+    settings.xAxis.fontSize.value = fontSize;
+    settings.xAxis.percentile.value = density;
+
+    const margin: IMargin = { top: 0, right: 0, bottom: 0, left: 0 };
+
+    return {
+        additionalMargin: margin,
+        axis,
+        colorPalette: createColorPalette(),
+        margin,
+        settings: settings.xAxis,
+        viewport,
+    };
+}
+
+/**
+ * Reads every rendered X-axis tick as { x: <center position>, textWidth: <rendered width> }.
+ * Ticks are rendered by d3-axis as `<g class="tick">` containing a centered `<text>`.
+ */
+function getRenderedTicks(rootElement: Element): Array<{ x: number; textWidth: number; text: string }> {
+    const tickGroups: NodeListOf<Element> = rootElement.querySelectorAll(".visualXAxisContainer .tick");
+
+    return Array.from(tickGroups).map((tickGroup: Element) => {
+        const transform: string = tickGroup.getAttribute("transform") || "";
+        const match: RegExpMatchArray | null = transform.match(/translate\(\s*([\d.-]+)/);
+        const x: number = match ? parseFloat(match[1]) : 0;
+
+        const textElement: SVGTextElement | null = tickGroup.querySelector("text");
+        const text: string = textElement ? (textElement.textContent || "") : "";
+        const textWidth: number = textElement ? textElement.getBoundingClientRect().width : 0;
+
+        return { x, textWidth, text };
+    });
+}
+
+describe("XAxisComponent tick label overlap", () => {
+    const minDate: Date = new Date(2017, 0, 1);
+    const maxDate: Date = new Date(2017, 6, 1);
+
+    function renderAxis(
+        viewport: powerbi.IViewport,
+        fontSize: number,
+        density: number = 100,
+        axis: IDataRepresentationX = buildDateAxis(minDate, maxDate),
+    ): Element {
+        const rootElement: HTMLElement = testDom(viewport.height.toString(), viewport.width.toString());
+        const element: Selection<HTMLElement, any, any, any> = d3Select(rootElement);
+
+        const xAxisComponent: XAxisComponent = new XAxisComponent({ element });
+
+        const options: IXAxisComponentRenderOptions = createRenderOptions(viewport, fontSize, density, axis);
+
+        xAxisComponent.preRender(options);
+        xAxisComponent.render(options);
+
+        return rootElement;
+    }
+
+    it("should not render overlapping tick labels when the visual is narrow and the font size is large", () => {
+        const rootElement: Element = renderAxis({ width: 300, height: 250 }, 24);
+
+        const ticks = getRenderedTicks(rootElement);
+
+        // Sanity check: the axis actually rendered some ticks with text - otherwise this test
+        // would trivially (and falsely) pass.
+        expect(ticks.length).toBeGreaterThan(0);
+
+        const sortedTicks = ticks.slice().sort((a, b) => a.x - b.x);
+
+        for (let i = 0; i < sortedTicks.length - 1; i++) {
+            const current = sortedTicks[i];
+            const next = sortedTicks[i + 1];
+
+            const gap: number = next.x - current.x;
+            const requiredGap: number = (current.textWidth / 2) + (next.textWidth / 2);
+
+            // A small tolerance accounts for anti-aliasing/measurement rounding - it must not be
+            // large enough to hide a real overlap regression.
+            const tolerance: number = 1;
+
+            expect(gap + tolerance).toBeGreaterThanOrEqual(requiredGap);
+        }
+    });
+
+    it("should not truncate every tick label with an ellipsis when ticks can instead be thinned out", () => {
+        const rootElement: Element = renderAxis({ width: 300, height: 250 }, 24);
+
+        const ticks = getRenderedTicks(rootElement);
+
+        expect(ticks.length).toBeGreaterThan(0);
+
+        const truncatedTickCount: number = ticks.filter((tick) => tick.text.indexOf("…") !== -1).length;
+
+        // It is acceptable for a single remaining tick to still be truncated if there truly is
+        // no room left (the last-resort safety net) - but it must not be the *default* strategy
+        // used for every tick, which produces an unreadable "Jan …", "Feb …", "Mar …" axis.
+        expect(truncatedTickCount).toBeLessThan(ticks.length);
+    });
+
+    it("should still render full, untruncated labels when there is plenty of space", () => {
+        const rootElement: Element = renderAxis({ width: 1200, height: 400 }, 9);
+
+        const ticks = getRenderedTicks(rootElement);
+
+        expect(ticks.length).toBeGreaterThan(0);
+
+        ticks.forEach((tick) => {
+            expect(tick.text.indexOf("…")).toBe(-1);
+            expect(tick.text.length).toBeGreaterThan(0);
+        });
+    });
+
+    it("should not throw and should not divide by zero when only a single tick can be shown", () => {
+        expect(() => {
+            renderAxis({ width: 40, height: 150 }, 24);
+        }).not.toThrow();
+    });
+
+    describe("tick density slider sweep", () => {
+        // The density slider (settings.xAxis.percentile) ranges from 0 to 100 and directly
+        // feeds getAmountOfTicksByDensity(). The refit loop mutates this.maxElementWidth and
+        // recreates the axis, so it must keep producing a sane (non-zero, non-NaN, finite)
+        // tick count and valid tick transforms across the whole density range, for both a
+        // narrow/large-font scenario (where refits are expected to happen) and a wide/small-font
+        // scenario (where refits should be a no-op).
+        const densities: number[] = [0, 1, 10, 25, 50, 75, 90, 99, 100];
+
+        densities.forEach((density: number) => {
+            it(`should render a sane, finite tick count at density=${density} when narrow with a large font`, () => {
+                const rootElement: Element = renderAxis({ width: 300, height: 250 }, 24, density);
+                const ticks = getRenderedTicks(rootElement);
+
+                expect(ticks.length).toBeGreaterThan(0);
+
+                ticks.forEach((tick) => {
+                    expect(isNaN(tick.x)).toBe(false);
+                    expect(isFinite(tick.x)).toBe(true);
+                });
+            });
+
+            it(`should render a sane, finite tick count at density=${density} when wide with a small font`, () => {
+                const rootElement: Element = renderAxis({ width: 1200, height: 400 }, 9, density);
+                const ticks = getRenderedTicks(rootElement);
+
+                expect(ticks.length).toBeGreaterThan(0);
+
+                ticks.forEach((tick) => {
+                    expect(isNaN(tick.x)).toBe(false);
+                    expect(isFinite(tick.x)).toBe(true);
+                });
+            });
+        });
+    });
+
+    describe("axis types other than Date", () => {
+        it("should not overlap tick labels for a categorical (string) X axis when narrow with a large font", () => {
+            const categories: string[] = [
+                "Category Alpha", "Category Beta", "Category Gamma",
+                "Category Delta", "Category Epsilon", "Category Zeta",
+            ];
+            const axis: IDataRepresentationX = buildStringAxis(categories);
+
+            const rootElement: Element = renderAxis({ width: 300, height: 250 }, 24, 100, axis);
+            const ticks = getRenderedTicks(rootElement);
+
+            expect(ticks.length).toBeGreaterThan(0);
+
+            const sortedTicks = ticks.slice().sort((a, b) => a.x - b.x);
+
+            for (let i = 0; i < sortedTicks.length - 1; i++) {
+                const current = sortedTicks[i];
+                const next = sortedTicks[i + 1];
+
+                const gap: number = next.x - current.x;
+                const requiredGap: number = (current.textWidth / 2) + (next.textWidth / 2);
+                const tolerance: number = 1;
+
+                expect(gap + tolerance).toBeGreaterThanOrEqual(requiredGap);
+            }
+        });
+
+        it("should never render zero tick labels for a numeric X axis even when the refit loop is forced to grow past the available width", () => {
+            // Unlike DateType axes (floored at MinAmountOfTicksForDates in axisHelper.ts),
+            // the NumberType branch of createScale() has no floor on the computed tick count -
+            // it can legitimately be driven to 0 if minOrdinalRectThickness grows past the
+            // available pixel span. Forcing the measured label width to be huge reproduces the
+            // exact condition that used to cause this regression, deterministically.
+            const axis: IDataRepresentationX = buildNumberAxis(0, 100);
+            const viewport: powerbi.IViewport = { width: 120, height: 150 };
+
+            const rootElement: HTMLElement = testDom(viewport.height.toString(), viewport.width.toString());
+            const element: Selection<HTMLElement, any, any, any> = d3Select(rootElement);
+
+            const xAxisComponent: XAxisComponent = new XAxisComponent({ element });
+
+            spyOn(xAxisComponent as any, "getActualMaxTickLabelWidth").and.returnValue(100000);
+
+            const options: IXAxisComponentRenderOptions = createRenderOptions(viewport, 24, 100, axis);
+
+            expect(() => {
+                xAxisComponent.preRender(options);
+                xAxisComponent.render(options);
+            }).not.toThrow();
+
+            const ticks = getRenderedTicks(rootElement);
+
+            expect(ticks.length).toBeGreaterThan(0);
+        });
+    });
+});

--- a/src/visualComponent/axes/xAxisComponent.ts
+++ b/src/visualComponent/axes/xAxisComponent.ts
@@ -129,7 +129,17 @@ export class XAxisComponent
         );
 
         this.maxElementWidth = labelMeasurementService.getLabelWidth(
-            [axis.min, axis.max],
+            // For a categorical (string) axis, axis.scale.getDomain() already contains
+            // every category label the axis can show - not just the endpoints - so any
+            // one of them (e.g. a longer middle category) can be the widest rendered
+            // label. Measuring only [axis.min, axis.max] under-estimated label width in
+            // that case, which fed an under-estimated minOrdinalRectThickness into the
+            // tick-count/density calculation and let too many ticks be selected.
+            // Scalar (numeric/date) axes don't have discrete categories to sample - the
+            // domain is just [min, max] - so behavior there is unchanged.
+            axis.scale.isCategorical && domain.length
+                ? domain
+                : [axis.min, axis.max],
             this.formatter,
             fontSize,
             settings.font.fontFamily.value,
@@ -169,14 +179,18 @@ export class XAxisComponent
         } = options;
 
         const width: number = Math.max(0, viewport.width - margin.left - margin.right);
+        const domain: any[] = axis.scale.getDomain();
+        const isScalar: boolean = !axis.scale.isCategorical;
 
         this.axisProperties = this.getAxisProperties(
             width,
-            axis.scale.getDomain(),
+            domain,
             axis.metadata,
-            !axis.scale.isCategorical,
+            isScalar,
             settings.percentile.value,
         );
+
+        this.refitAxisPropertiesToActualLabelWidth(width, domain, axis, settings, isScalar);
 
         if (!this.isShown) {
             return;
@@ -195,30 +209,7 @@ export class XAxisComponent
         this.gElement.attr("transform", svgManipulation.translate(0, 0));
 
         this.axisProperties.axis
-            .tickFormat((item: number) => {
-                const currentValue: any = axis.axisType === DataRepresentationTypeEnum.DateType
-                    ? new Date(item)
-                    : item;
-
-                const formattedLabel: string = axis.axisType === DataRepresentationTypeEnum.DateType
-                    ? this.axisProperties.formatter.format(currentValue)
-                    : this.formatter.format(currentValue);
-
-                let availableWidth: number = NaN;
-
-                if (this.maxElementWidth > width) {
-                    availableWidth = width;
-                }
-
-                if (!isNaN(availableWidth)) {
-                    return textMeasurementService.getTailoredTextOrDefault(
-                        labelMeasurementService.getTextProperties(formattedLabel, settings.fontSizeInPx, settings.font.fontFamily.value),
-                        availableWidth,
-                    );
-                }
-
-                return formattedLabel;
-            });
+            .tickFormat((item: number) => this.getFormattedAndFittedTickLabel(item, axis, settings, width));
 
         const isHighContrast: boolean = colorPalette.isHighContrast;
         
@@ -291,6 +282,157 @@ export class XAxisComponent
             tickLabelPadding: undefined,
             useTickIntervalForDisplayUnits: true,
         });
+    }
+
+    /**
+     * The label width used to pick the tick count (this.maxElementWidth, computed in
+     * preRender()) is only an estimate - the formatter that actually renders date-axis labels
+     * (this.axisProperties.formatter) is only resolved *after* createAxis() picks
+     * tickValues/bestTickCount, so it can legitimately produce wider text than assumed.
+     * If the real widest label doesn't fit in its own tick slot (xLabelMaxWidth), recreate the
+     * axis with a bigger thickness estimate so *fewer, wider-spaced* ticks are chosen - instead
+     * of keeping the original tick count and truncating every single label down to an
+     * unreadable "Jan …", "Feb …", "Mar …" run.
+     */
+    private refitAxisPropertiesToActualLabelWidth(
+        width: number,
+        domain: any[],
+        axis: IDataRepresentationX,
+        settings: AxisDescriptor,
+        isScalar: boolean,
+    ): void {
+        const maxRefitAttempts: number = 4;
+
+        for (let attempt: number = 0; attempt < maxRefitAttempts; attempt++) {
+            const actualMaxLabelWidth: number = this.getActualMaxTickLabelWidth(axis, settings);
+            const perTickWidth: number = this.axisProperties.xLabelMaxWidth;
+            const tickCount: number = this.getTicks().length;
+
+            const labelDoesNotFit: boolean =
+                !isNaN(actualMaxLabelWidth)
+                && actualMaxLabelWidth > 0
+                && !isNaN(perTickWidth)
+                && perTickWidth > 0
+                && actualMaxLabelWidth > perTickWidth;
+
+            // Once we are down to a single tick, xLabelMaxWidth already equals the full
+            // available width - there is no more room to gain by asking for even fewer
+            // ticks, so stop iterating and let the render-time truncation guard handle the
+            // (now unavoidable) case where a single label still doesn't fit.
+            if (!labelDoesNotFit || tickCount <= 1 || actualMaxLabelWidth <= this.maxElementWidth) {
+                break;
+            }
+
+            const previousAxisProperties = this.axisProperties;
+            const previousMaxElementWidth: number = this.maxElementWidth;
+
+            this.maxElementWidth = actualMaxLabelWidth;
+
+            this.axisProperties = this.getAxisProperties(
+                width,
+                domain,
+                axis.metadata,
+                isScalar,
+                settings.percentile.value,
+            );
+
+            // Not every axis type floors its tick count at 1 the way date axes do (see
+            // MinAmountOfTicksForDates in axisHelper.ts) - e.g. a purely numeric axis can have
+            // its tick count computed straight down to 0 once minOrdinalRectThickness exceeds
+            // the available pixel span. Rendering zero tick labels is worse than the
+            // overlap/truncation this loop exists to avoid, so undo this attempt and stop.
+            if (this.getTicks().length === 0) {
+                this.axisProperties = previousAxisProperties;
+                this.maxElementWidth = previousMaxElementWidth;
+
+                break;
+            }
+        }
+    }
+
+    /**
+     * Formats a tick value the way render() will draw it, then shortens it with an ellipsis
+     * only if it still doesn't fit the space actually available to it - its own tick slot
+     * (xLabelMaxWidth) first, falling back to the whole axis width as a last resort. Comparing
+     * against the whole axis width alone almost never triggers for categorical/date labels,
+     * which is why labels used to overlap instead of being shortened when the visual got
+     * narrower and/or the font got larger.
+     */
+    private getFormattedAndFittedTickLabel(
+        item: number,
+        axis: IDataRepresentationX,
+        settings: AxisDescriptor,
+        width: number,
+    ): string {
+        const formattedLabel: string = this.formatTickValue(item, axis);
+
+        const formattedLabelWidth: number = labelMeasurementService.getTextWidth(
+            formattedLabel,
+            settings.fontSizeInPx,
+            settings.font.fontFamily.value,
+        );
+
+        const perTickWidth: number = this.axisProperties.xLabelMaxWidth;
+
+        let availableWidth: number = NaN;
+
+        if (!isNaN(perTickWidth) && perTickWidth > 0 && formattedLabelWidth > perTickWidth) {
+            availableWidth = perTickWidth;
+        } else if (formattedLabelWidth > width) {
+            availableWidth = width;
+        }
+
+        if (!isNaN(availableWidth)) {
+            return textMeasurementService.getTailoredTextOrDefault(
+                labelMeasurementService.getTextProperties(formattedLabel, settings.fontSizeInPx, settings.font.fontFamily.value),
+                availableWidth,
+            );
+        }
+
+        return formattedLabel;
+    }
+
+    /**
+     * Formats a raw tick value the same way it will be rendered on the axis. For date axes the
+     * label is produced by this.axisProperties.formatter, which is only resolved once
+     * createAxis() has picked the tick count/interval - it is not known ahead of time (see
+     * this.getValueFormatterOfXAxis() for why the preRender() estimate can differ).
+     */
+    private formatTickValue(item: number, axis: IDataRepresentationX): string {
+        const currentValue: any = axis.axisType === DataRepresentationTypeEnum.DateType
+            ? new Date(item)
+            : item;
+
+        return axis.axisType === DataRepresentationTypeEnum.DateType
+            ? this.axisProperties.formatter.format(currentValue)
+            : this.formatter.format(currentValue);
+    }
+
+    /**
+     * Measures the widest label among the ticks currently selected by this.axisProperties
+     * (i.e. the labels that will actually be drawn at the current tick count), using the same
+     * formatter/font that render() will use. Used to detect when the tick-count estimate from
+     * preRender() under-shot the real label width, so the axis can be recreated with fewer,
+     * wider-spaced ticks instead of truncating every label.
+     */
+    private getActualMaxTickLabelWidth(axis: IDataRepresentationX, settings: AxisDescriptor): number {
+        const tickValues: any[] = (this.axisProperties && this.axisProperties.axis.tickValues()) || [];
+
+        if (!tickValues.length) {
+            return NaN;
+        }
+
+        return tickValues.reduce((maxWidth: number, tickValue: any) => {
+            const formattedLabel: string = this.formatTickValue(tickValue, axis);
+
+            const labelWidth: number = labelMeasurementService.getTextWidth(
+                formattedLabel,
+                settings.fontSizeInPx,
+                settings.font.fontFamily.value,
+            );
+
+            return Math.max(maxWidth, labelWidth);
+        }, 0);
     }
 
     private areRenderOptionsValid(options: IXAxisComponentRenderOptions): boolean {

--- a/src/visualComponent/axes/xAxisComponent.ts
+++ b/src/visualComponent/axes/xAxisComponent.ts
@@ -265,6 +265,7 @@ export class XAxisComponent
         metaDataColumn: powerbi.DataViewMetadataColumn,
         isScalar: boolean,
         density: number,
+        minOrdinalRectThickness: number = this.maxElementWidth + this.labelPadding,
     ) {
         return createAxis({
             dataDomain,
@@ -275,7 +276,7 @@ export class XAxisComponent
             isScalar,
             isVertical: false,
             metaDataColumn,
-            minOrdinalRectThickness: this.maxElementWidth + this.labelPadding,
+            minOrdinalRectThickness,
             outerPadding: 0,
             pixelSpan,
             shouldClamp: false,
@@ -293,6 +294,14 @@ export class XAxisComponent
      * axis with a bigger thickness estimate so *fewer, wider-spaced* ticks are chosen - instead
      * of keeping the original tick count and truncating every single label down to an
      * unreadable "Jan …", "Feb …", "Mar …" run.
+     *
+     * The thickness is threaded through getAxisProperties() as a local, never stored on the
+     * instance, so this render-time refit can't leak into a later render() call that isn't
+     * preceded by preRender(). The loop terminates by convergence rather than a fixed attempt
+     * cap: it only continues while the required thickness strictly grows and the tick count
+     * strictly shrinks (bounded below by 1), so a handful of passes is guaranteed regardless of
+     * tick count. The per-slot truncation in getFormattedAndFittedTickLabel() remains the final
+     * fallback once no more ticks can be dropped.
      */
     private refitAxisPropertiesToActualLabelWidth(
         width: number,
@@ -301,9 +310,9 @@ export class XAxisComponent
         settings: AxisDescriptor,
         isScalar: boolean,
     ): void {
-        const maxRefitAttempts: number = 4;
+        let thickness: number = this.maxElementWidth + this.labelPadding;
 
-        for (let attempt: number = 0; attempt < maxRefitAttempts; attempt++) {
+        for (;;) {
             const actualMaxLabelWidth: number = this.getActualMaxTickLabelWidth(axis, settings);
             const perTickWidth: number = this.axisProperties.xLabelMaxWidth;
             const tickCount: number = this.getTicks().length;
@@ -319,14 +328,22 @@ export class XAxisComponent
             // available width - there is no more room to gain by asking for even fewer
             // ticks, so stop iterating and let the render-time truncation guard handle the
             // (now unavoidable) case where a single label still doesn't fit.
-            if (!labelDoesNotFit || tickCount <= 1 || actualMaxLabelWidth <= this.maxElementWidth) {
+            if (!labelDoesNotFit || tickCount <= 1) {
                 break;
             }
 
-            const previousAxisProperties = this.axisProperties;
-            const previousMaxElementWidth: number = this.maxElementWidth;
+            const requiredThickness: number = actualMaxLabelWidth + this.labelPadding;
 
-            this.maxElementWidth = actualMaxLabelWidth;
+            // Convergence guard #1 (fixed point on width): if asking for the actual label
+            // width wouldn't widen the tick slot beyond what we already requested, another
+            // pass can't thin the axis any further - stop.
+            if (requiredThickness <= thickness) {
+                break;
+            }
+
+            thickness = requiredThickness;
+
+            const previousAxisProperties = this.axisProperties;
 
             this.axisProperties = this.getAxisProperties(
                 width,
@@ -334,17 +351,27 @@ export class XAxisComponent
                 axis.metadata,
                 isScalar,
                 settings.percentile.value,
+                thickness,
             );
+
+            const newTickCount: number = this.getTicks().length;
 
             // Not every axis type floors its tick count at 1 the way date axes do (see
             // MinAmountOfTicksForDates in axisHelper.ts) - e.g. a purely numeric axis can have
             // its tick count computed straight down to 0 once minOrdinalRectThickness exceeds
             // the available pixel span. Rendering zero tick labels is worse than the
             // overlap/truncation this loop exists to avoid, so undo this attempt and stop.
-            if (this.getTicks().length === 0) {
+            if (newTickCount === 0) {
                 this.axisProperties = previousAxisProperties;
-                this.maxElementWidth = previousMaxElementWidth;
 
+                break;
+            }
+
+            // Convergence guard #2 (fixed point on tick count): if a wider thickness didn't
+            // actually drop any ticks, further passes won't either - stop. Because the tick
+            // count decreases monotonically toward 1 whenever the loop does make progress,
+            // this guarantees termination without a fixed attempt cap.
+            if (newTickCount >= tickCount) {
                 break;
             }
         }


### PR DESCRIPTION
Fixes X-axis tick labels overlapping when the visual is narrowed and the axis font size is increased.

- Compare label width against its own tick slot instead of the whole axis width, so overlong labels get truncated per-tick rather than never
- Estimate label width from the full category domain (not just min/max) so tick count starts closer to correct
- Recreate the axis with a bigger width estimate when a rendered label still doesn't fit, thinning out ticks instead of truncating every label to "…"
- Prevent the above from ever collapsing a numeric axis to zero visible ticks
- Add regression tests (date/numeric/string axes, density slider 0–100)